### PR TITLE
connection-reset-guard: Ignore tls socket error

### DIFF
--- a/lib/request-pipeline/connection-reset-guard.js
+++ b/lib/request-pipeline/connection-reset-guard.js
@@ -18,6 +18,13 @@ connectionResetDomain.on('error', err => {
   // https://github.com/nodejs/node/blob/8b4af64f50c5e41ce0155716f294c24ccdecad03/test/parallel/test-http-destroyed-socket-write2.js
   if (err.code === 'ECONNRESET' || !_osFamily.default.win && err.code === 'EPIPE' || _osFamily.default.win && err.code === 'ECONNABORTED') return;
 
+  // There seems to be an error case where OpenSSL tries to read from a connection, and an SSL_ERROR_SYSCALL error (code 5)
+  // is returned. However, the error queue is empty (or node's error handling is wrong - I have no idea). However, I'm led
+  // to believe it's the result of an I/O error/protocol violation. The client expects to read  more data, but the remote
+  // server has closed the connection.
+  //
+  // I haven't confirmed this yet - or read enough of the OpenSSL docs to confirm that the error handling code is correct,
+  // but this will catch and ignore the error - which is actually a TLSSocket object.
   if (err.domainEmitter && err.domainEmitter.constructor && err.domainEmitter.constructor.name == 'TLSSocket') {
     return;
   }

--- a/lib/request-pipeline/connection-reset-guard.js
+++ b/lib/request-pipeline/connection-reset-guard.js
@@ -17,6 +17,11 @@ connectionResetDomain.on('error', err => {
   // when the connection is broken in some cases on MacOS and Linux
   // https://github.com/nodejs/node/blob/8b4af64f50c5e41ce0155716f294c24ccdecad03/test/parallel/test-http-destroyed-socket-write2.js
   if (err.code === 'ECONNRESET' || !_osFamily.default.win && err.code === 'EPIPE' || _osFamily.default.win && err.code === 'ECONNABORTED') return;
+
+  if (err.domainEmitter && err.domainEmitter.constructor && err.domainEmitter.constructor.name == 'TLSSocket') {
+    return;
+  }
+
   connectionResetDomain.removeAllListeners('error');
   throw err;
 });


### PR DESCRIPTION
Background: We've been seeing testcafe failures that present as an
uncaught exception resulting in the process exiting with status 7. The
error message points to a line of code in a brotli library containing a
process.on("uncaughtException") handler.

After removing the uncaught exception handler, the underlying error was
an empty exception (with no message) with an attached domain emitter.
This domain emitter is the connection reset guard here. The error object
is actually a TLSSocket object.

After analyzing a few core dumps and the output after running with
NODE_DEBUG=tls and NODE_DEBUG_NATIVE=tls, I determined that the
underlying error was being thrown from OpenSSL. The actual error being
thrown there is SSL_ERROR_SYSCALL (error code 5) - described an a
general I/O error in the manpage.

Node attempts to get the actual error message from the OpenSSL error
queue here:
https://github.com/nodejs/node/blob/master/src/tls_wrap.cc#L425

However, the error queue doesn't appear to contain an actual error
message. This leads me to believe that we're encountering some sort of
protocol violation - an unexpected EOF when there should be more data to
read. We've noticed this mostly occurring on websocket connections (to
various marketing/analytics type services). The connection is probably
being closed by the remote server. I'd like to confirm this by capturing
the network traffic, but that's time consuming and I haven't gotten
around to it.

So... for now, we're just going to capture and ignore these errors and
let hammerhead retry.