### PR TITLE
P2 16.2.3 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ test/playground/upload-storage
 node_modules
 .idea
 .vscode
-lib
 package-lock.json
 src/**/*.js

--- a/lib/request-pipeline/context.js
+++ b/lib/request-pipeline/context.js
@@ -340,10 +340,6 @@ class RequestPipelineContext {
     if (mock && !this.mock) this.mock = mock;
   }
 
-  isDestResBodyMalformed() {
-    return !this.destResBody || this.destResBody.length.toString() !== this.destRes.headers['content-length'];
-  }
-
   getOnResponseEventData({
     includeBody
   }) {

--- a/lib/request-pipeline/utils.js
+++ b/lib/request-pipeline/utils.js
@@ -58,6 +58,13 @@ function sendRequest(ctx) {
     req.on('error', err => {
       // NOTE: Sometimes the underlying socket emits an error event. But if we have a response body,
       // we can still process such requests. (B234324)
+
+      // P2 Note: Issue -> https://prodperfect.monday.com/boards/451757477/pulses/570777168
+      // We have noticed one instance where the 'end' event is not being emitted for finished requests
+      // This is manifesting as server requests being left open then all closed at the same time with associated
+      // ECONNRESET errors. Because these requests weren't properly ended, any page errors
+      // are redirected which is throwing an error that you can't set headers after sending a response to the client.
+      // For now, the solution is to check if the response finished and ignore the error if it has.
       if (ctx.isDestResReadableEnded || err.code === 'ECONNRESET' && ctx.res.finished) {
           resolve();
       } else {

--- a/lib/request-pipeline/utils.js
+++ b/lib/request-pipeline/utils.js
@@ -58,12 +58,12 @@ function sendRequest(ctx) {
     req.on('error', err => {
       // NOTE: Sometimes the underlying socket emits an error event. But if we have a response body,
       // we can still process such requests. (B234324)
-      if (ctx.isDestResBodyMalformed()) {
-        error(ctx, (0, _messages.getText)(_messages.MESSAGE.destConnectionTerminated, ctx.dest.url, err.toString()));
-        ctx.goToNextStage = false;
+      if (ctx.isDestResReadableEnded || err.code === 'ECONNRESET' && ctx.res.finished) {
+          resolve();
+      } else {
+          error(ctx, (0, _messages.getText)(_messages.MESSAGE.destConnectionTerminated, ctx.dest.url, err.toString()));
+          resolve();
       }
-
-      resolve();
     });
     req.on('fatalError', err => {
       error(ctx, err);

--- a/src/request-pipeline/context.ts
+++ b/src/request-pipeline/context.ts
@@ -390,10 +390,6 @@ export default class RequestPipelineContext {
             this.mock = mock;
     }
 
-    isDestResBodyMalformed (): boolean {
-        return !this.destResBody || this.destResBody.length.toString() !== this.destRes.headers['content-length'];
-    }
-
     getOnResponseEventData ({ includeBody }: { includeBody: boolean }): OnResponseEventData[] {
         return this.onResponseEventData.filter(eventData => eventData.opts.includeBody === includeBody);
     }

--- a/src/request-pipeline/utils.ts
+++ b/src/request-pipeline/utils.ts
@@ -40,12 +40,12 @@ export function sendRequest (ctx: RequestPipelineContext) {
         req.on('error', err => {
             // NOTE: Sometimes the underlying socket emits an error event. But if we have a response body,
             // we can still process such requests. (B234324)
-            if (ctx.isDestResBodyMalformed()) {
+            if (ctx.isDestResReadableEnded || (err.code === 'ECONNRESET' && ctx.res.finished)) {
+                resolve();
+            } else {
                 error(ctx, getText(MESSAGE.destConnectionTerminated, ctx.dest.url, err.toString()));
-                ctx.goToNextStage = false;
+                resolve();
             }
-
-            resolve();
         });
 
         req.on('fatalError', err => {

--- a/src/request-pipeline/utils.ts
+++ b/src/request-pipeline/utils.ts
@@ -40,7 +40,7 @@ export function sendRequest (ctx: RequestPipelineContext) {
         req.on('error', err => {
             // NOTE: Sometimes the underlying socket emits an error event. But if we have a response body,
             // we can still process such requests. (B234324)
-            if (ctx.isDestResReadableEnded || (err.code === 'ECONNRESET' && ctx.res.finished)) {
+            if (ctx.isDestResReadableEnded || (err.code === 'ECONNRESET' && (ctx.res as any).finished)) {
                 resolve();
             } else {
                 error(ctx, getText(MESSAGE.destConnectionTerminated, ctx.dest.url, err.toString()));


### PR DESCRIPTION
<!--
Thank you for your contribution.

Before making a PR, please read our contributing guidelines at
https://github.com/DevExpress/testcafe-hammerhead/blob/master/CONTRIBUTING.md#code-contribution

We recommend creating a *draft* PR, so that you can mark it as 'ready for review' when you are done.
-->

## Purpose
_Describe the problem you want to address or the feature you want to implement._
We're seeing a node error suggesting that Hammerhead has been trying to call setHeaders() on a request that has already been sent to the client. It looks like requests to beta.volza.com and associated server assets are not being properly closed out. This is manifesting as Hammerhead not knowing the requests had completed as well as the connections all being terminated unexpectedly and a bunch of ECONNRESET errors.

Because one of these ECONNRESET errors is a call to load the main page, Hammerhead sees this as an unrecoverable error and tries to redirect to an error page. We can confirm that the request finished then just ignore it.

## Approach
_Describe how your changes address the issue or implement the desired functionality in as much detail as possible._
This handles the very specific case of an ECONNRESET error with an associated response that was the finished property set to true. While it's true the end property should only be set to true after res.end() is called, for some reason it seems that end event is not actually being either emitted or captured.

If we encounter an ECONNRESET error that has res.finished = true we just ignore the error.
